### PR TITLE
Make the API consistent with native 2.0 SDKs

### DIFF
--- a/cordova/src/PWAExtension.ts
+++ b/cordova/src/PWAExtension.ts
@@ -1,0 +1,54 @@
+import { WultraMobileToken } from "./WultraMobileToken"
+import { WMTUserAgent } from "./networking/WMTNetworking"
+
+export interface PowerAuth {
+
+    /**
+     * Creates Wultra Mobile Token services from on top of the `PowerAuthSDK`.
+     * URL from the `PowerAuthSDK` instance is used for services.
+     *
+     * `PowerAuthSDK` instance needs to be activated when calling any method of this class; otherwise, an error will be thrown.
+     * @param acceptLanguage Optionally sets the accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+     *                       The default value is "en".
+     *                       The value can be further modified in the each service object individualy.
+     *                       Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+     *                       Response texts are based on this setting. For example when "de" is set, server
+     *                       will return operation texts in german (if available).
+     * @param userAgent Optionally sets the User agent that will be used in a HTTP hader.
+     *                  Note that user-agent can be overriden by request processor in each API call.
+     * @returns Mobile Token SDK main wrapper.
+     */
+    createWultraMobileToken(
+        acceptLanguage?: string,
+        userAgent?: WMTUserAgent | string
+    ): WultraMobileToken
+}
+
+// An ambiguous type hack to make TS happy with the actual prototype implementation.
+interface PowerAuthConstructor {
+    prototype: PowerAuth;
+}
+
+declare var PowerAuth: PowerAuthConstructor;
+
+/**
+ * Creates Wultra Mobile Token services from on top of the `PowerAuthSDK`.
+ * URL from the `PowerAuthSDK` instance is used for services.
+ *
+ * `PowerAuthSDK` instance needs to be activated when calling any method of this class; otherwise, an error will be thrown.
+ * @param acceptLanguage Optionally sets the accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+ *                       The default value is "en".
+ *                       The value can be further modified in the each service object individualy.
+ *                       Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+ *                       Response texts are based on this setting. For example when "de" is set, server
+ *                       will return operation texts in german (if available).
+ * @param userAgent Optionally sets the User agent that will be used in a HTTP hader.
+ *                  Note that user-agent can be overriden by request processor in each API call.
+ * @returns Mobile Token SDK main wrapper.
+ */
+PowerAuth.prototype.createWultraMobileToken = function (
+    acceptLanguage?: string,
+    userAgent?: WMTUserAgent | string
+) {
+    return new WultraMobileToken(this, acceptLanguage, userAgent)
+}

--- a/docs/Example-Usage.md
+++ b/docs/Example-Usage.md
@@ -19,7 +19,7 @@ async function exampleUsage(powerAuth: PowerAuth) {
     const mtoken = powerAuth.createWultraMobileToken() // create the WultraMobileToken instance
     mtoken.setAcceptLanguage("de") // set "requested content" to german language (default is english - "en")
     try {
-        const listResponse = await this.mtoken.operations.pendingList() // get operation list
+        const listResponse = await this.mtoken.operations.getOperations() // get operation list
 
         if (listResponse.responseObject && listResponse.responseObject.length > 0) { // make sure that we retrieved some operations
             

--- a/docs/Example-Usage.md
+++ b/docs/Example-Usage.md
@@ -16,7 +16,7 @@ Example Typescript usage:
 // More about PowerAuth SDK can be found here: https://github.com/wultra/react-native-powerauth-mobile-sdk
 
 async function exampleUsage(powerAuth: PowerAuth) {
-    const mtoken = new WultraMobileToken(powerAuth, "https://my-instance.mycompany.com/enrollment-server") // create the WultraMobileToken instance
+    const mtoken = powerAuth.createWultraMobileToken() // create the WultraMobileToken instance
     mtoken.setAcceptLanguage("de") // set "requested content" to german language (default is english - "en")
     try {
         const listResponse = await this.mtoken.operations.pendingList() // get operation list

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -44,12 +44,12 @@ The code of the library is open source and you can freely browse it in our GitHu
 
 ## Support and compatibility
 
-| Version | React-Native<sup>1</sup> | Cordova   | PowerAuth JS SDK | Support Status  |
+| Version | React Native<sup>1</sup> | Cordova   | PowerAuth JS SDK | Support Status  |
 |---------|--------------------------|-----------|------------------|-----------------|
 | `1.0.x` | `0.73+`                  | `12.0.0+` | `3.0.x`          | Fully supported |
 
 <!-- begin box info -->
-> Note 1: The library may also work with other React-Native versions but we don't guarantee compatibility. The specified version is the version that we use for the development and for the tests.
+> Note 1: The library may also work with other React Native versions but we don't guarantee compatibility. The specified version is the version that we use for the development and for the tests.
 <!-- end -->
 
 ## License

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -37,7 +37,9 @@ import { PowerAuth } from 'react-native-powerauth-mobile-sdk';
 function createMtokenInstance() {
     const powerAuth = new PowerAuth("my-instance")
     // note that an activated PowerAuth instance is required. How to activate the PowerAuth instance, follow https://github.com/wultra/react-native-powerauth-mobile-sdk documentation.
-    const mtoken = new WultraMobileToken(powerAuth, "https://my-instance.mycompany.com/enrollment-server")
+    
+    // Then, use PowerAuth's helper function to create the mtoken instance:
+    const mtoken = powerAuth.createWultraMobileToken()
 }
 ```
 
@@ -71,7 +73,9 @@ pod install
 ```typescript
 const powerAuth = new PowerAuth("my-instance")
 // note that an activated PowerAuth instance is required. How to activate the PowerAuth instance, follow https://github.com/wultra/react-native-powerauth-mobile-sdk documentation.
-const mtoken = new WultraMobileToken(powerAuth, "https://my-instance.mycompany.com/enrollment-server")
+
+// Then, use PowerAuth's helper function to create the mtoken instance:
+const mtoken = powerAuth.createWultraMobileToken()
 ```
 
 ## Read Next

--- a/docs/Using-Inbox.md
+++ b/docs/Using-Inbox.md
@@ -26,7 +26,7 @@ Note: Before using `WMTInbox`, you need to have a `PowerAuth` object available a
 The instance of the `WMTInbox` can be accessed after creating the main object of the SDK:
 
 ```typescript
-const mtoken = new WultraMobileToken(powerAuthInstance, "https://my-instance.mycompany.com/enrollment-server")
+const mtoken = powerAuthInstance.createWultraMobileToken()
 const inbox = mtoken.inbox
 ```
 
@@ -38,7 +38,7 @@ To get the number of unread messages, use the following code:
 
 ```typescript
 try {
-    const resp = await this.mtoken.inbox.unreadCount()
+    const resp = await this.mtoken.inbox.getUnreadCount()
     if (resp.responseObject) {
         console.log(`There are ${resp.responseObject.countUnread} unread messages.`)
     } else {
@@ -56,7 +56,7 @@ Get a paged list of messages:
 ```typescript
 try {
     //Get page 0 of size 50, not not exclude unread messages
-    const resp = await this.mtoken.inbox.list(0, 50, false)
+    const resp = await this.mtoken.inbox.getMessageList(0, 50, false)
     if (resp.responseObject) {
         // process the message list
     } else {
@@ -74,7 +74,7 @@ Each message has its unique identifier. To get the body of the message, use the 
 ```typescript
 try {
     let messageId = messagesList[0].id
-    const resp = await this.mtoken.detail(messageId)
+    const resp = await this.mtoken.getMessageDetail(messageId)
     if (resp.responseObject) {
         // process the message
     } else {

--- a/docs/Using-Operations.md
+++ b/docs/Using-Operations.md
@@ -32,7 +32,7 @@ Note: Before using `WMTOperations`, you need to have a `PowerAuth` object availa
 The instance of the `WMTOperations` can be accessed after creating the main object of the SDK:
 
 ```typescript
-const mtoken = new WultraMobileToken(powerAuthInstance, "https://my-instance.mycompany.com/enrollment-server")
+const mtoken = powerAuthInstance.createWultraMobileToken()
 const operations = mtoken.operations
 ```
 
@@ -120,7 +120,7 @@ To reject an operation use `reject`. Operation rejection is confirmed by the pos
 // Reject operation with some reason
 async function reject(operation: WMTOnlineOperation, reason: "INCORRECT_DATA" | "UNEXPECTED_OPERATION" | "UNKNOWN" | string) {
     try {
-        const response = await this.operations.reject(operation, reason)
+        const response = await this.operations.reject(operation.id, reason)
         if (response.status == "OK") {
             // operation rejected
         } else {
@@ -140,7 +140,7 @@ To get a detail of the operation based on operation ID use `detail`. Operation d
 // Retrieve operation details based on the operation ID.
 async function getDetail(operationId: string) {
     try {
-        const response = await this.mtoken.operations.detail(operationId)
+        const response = await this.mtoken.operations.getDetail(operationId)
         if (response.responseObject) {
             // operation retrieved
         } else {
@@ -187,7 +187,7 @@ async function history(password: string) {
     const auth = PowerAuthAuthentication.password(password)
 
     try {
-        const response = await this.mtoken.operations.history(auth)
+        const response = await this.mtoken.operations.getHistory(auth)
         if (response.responseObject) {
             // history retrieved
         } else {
@@ -298,14 +298,13 @@ All available methods and attributes of `WMTOperations` API are:
 > Each call has a `requestProcessor` parameter - an option to modify the request.
 
 - `async pendingList(requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>>` - Retrieves pending operations from the server.
-- `async detail(operationId: string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation>>` - Retrieves operation detail based on operation ID.
+- `async getDetail(operationId: string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation>>` - Retrieves operation detail based on operation ID.
   - `operationId` - ID of the operation to retrieve.
-- `async history(authentication: PowerAuthAuthentication, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>>` - Retrieves operation history.
+- `async getHistory(authentication: PowerAuthAuthentication, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>>` - Retrieves operation history.
   - `authentication` - PowerAuth authentication object for signing.
 - `async authorize(operation: WMTOnlineOperation, authentication: PowerAuthAuthentication, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<void>>` - Authorize provided operation.
-  - `operation` - An operation to approve, retrieved from `getOperations` call or [created locally](#creating-a-custom-operation).
+  - `operation` - An operation to approve, retrieved from `pendingList` call or [created locally](#creating-a-custom-operation).
   - `authentication` - PowerAuth authentication object for operation signing.
-  - `callback` - Called when authorization request finishes.
 - `async reject(operationId: string, reason: "INCORRECT_DATA" | "UNEXPECTED_OPERATION" | "UNKNOWN" | string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<void>>` - Reject provided operation.
   - `operationId` - An operation to reject.
   - `reason` - Rejection reason.

--- a/docs/Using-Operations.md
+++ b/docs/Using-Operations.md
@@ -43,7 +43,7 @@ To fetch the list with pending operations, you can call:
 ```typescript
 async function fetch() {
     try {
-        const response = await this.operations.pendingList()
+        const response = await this.operations.getOperations()
         if (response.responseObject) {
             // process list
         } else {
@@ -297,13 +297,13 @@ All available methods and attributes of `WMTOperations` API are:
 
 > Each call has a `requestProcessor` parameter - an option to modify the request.
 
-- `async pendingList(requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>>` - Retrieves pending operations from the server.
+- `async getOperations(requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>>` - Retrieves pending operations from the server.
 - `async getDetail(operationId: string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation>>` - Retrieves operation detail based on operation ID.
   - `operationId` - ID of the operation to retrieve.
 - `async getHistory(authentication: PowerAuthAuthentication, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>>` - Retrieves operation history.
   - `authentication` - PowerAuth authentication object for signing.
 - `async authorize(operation: WMTOnlineOperation, authentication: PowerAuthAuthentication, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<void>>` - Authorize provided operation.
-  - `operation` - An operation to approve, retrieved from `pendingList` call or [created locally](#creating-a-custom-operation).
+  - `operation` - An operation to approve, retrieved from `getOperations` call or [created locally](#creating-a-custom-operation).
   - `authentication` - PowerAuth authentication object for operation signing.
 - `async reject(operationId: string, reason: "INCORRECT_DATA" | "UNEXPECTED_OPERATION" | "UNKNOWN" | string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<void>>` - Reject provided operation.
   - `operationId` - An operation to reject.
@@ -317,7 +317,7 @@ All available methods and attributes of `WMTOperations` API are:
 
 ## WMTUserOperation
 
-Operations objects retrieved through the `pendingList` or `detail` methods are called "user operations".
+Operations objects retrieved through the `getOperations` or `getDetail` methods are called "user operations".
 
 Under this abstract name, you can imagine for example "Login operation", which is a request for signing in to the online account in a web browser on another device. **In general, it can be any operation that can be either approved or rejected by the user.**
 
@@ -495,7 +495,7 @@ export interface WMTUserOperationProximityCheck {
 
 ## Creating a Custom Operation
 
-In some specific scenarios, you might need to approve or reject an operation that you received through a different channel than `pendingList`. In such cases, you can implement the `WMTOnlineOperation` interface in your custom class and then feed created objects to both `authorize` and `reject` methods.
+In some specific scenarios, you might need to approve or reject an operation that you received through a different channel than `getOperations`. In such cases, you can implement the `WMTOnlineOperation` interface in your custom class and then feed created objects to both `authorize` and `reject` methods.
 
 Definition of the `WMTOnlineOperation`:
 

--- a/docs/Using-Push.md
+++ b/docs/Using-Push.md
@@ -25,7 +25,7 @@ Note: `WMTPush` only registers the device to receive push notifications, it does
 The instance of the `WMTPush` can be accessed after creating the main object of the SDK:
 
 ```typescript
-const mtoken = new WultraMobileToken(powerAuthInstance, "https://my-instance.mycompany.com/enrollment-server")
+const mtoken = powerAuthInstance.createWultraMobileToken()
 const push = mtoken.push
 ```
 

--- a/exampleReactNative/ios/Podfile.lock
+++ b/exampleReactNative/ios/Podfile.lock
@@ -1246,8 +1246,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-powerauth-mobile-sdk (2.5.4):
-    - PowerAuth2 (~> 1.7.9)
+  - react-native-powerauth-mobile-sdk (3.0.0):
+    - PowerAuth2 (~> 1.7.10)
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1774,7 +1774,7 @@ SPEC CHECKSUMS:
   React-logger: 7b5b458327a1ff0d7e5a349430d1ed133dcebaa3
   React-Mapbuffer: 0d88ad9afa9e195dd7634424bde1d38e4129e646
   React-microtasksnativemodule: 17234f35d37e6ed388e18a6314210b3b9e051219
-  react-native-powerauth-mobile-sdk: 89303a4e8d0053baf8fdd3dff5efe59a60ce0c71
+  react-native-powerauth-mobile-sdk: 66e8e4ad6b43ffdf4ca5440c3365151236ef6859
   React-nativeconfig: 93fe8c85a8c40820c57814e30f3e44b94c995a7b
   React-NativeModulesApple: a4457b73e63e983db66d66612160006bccb00ad5
   React-perflogger: 3140b7778984a486db80d4d2aeaa266cae4eb8c7

--- a/exampleReactNative/package-lock.json
+++ b/exampleReactNative/package-lock.json
@@ -10757,7 +10757,7 @@
     "node_modules/react-native-mtoken-sdk": {
       "version": "0.1.0",
       "resolved": "file:../build/react-native/react-native-mtoken-sdk-0.1.0.tgz",
-      "integrity": "sha512-qcR4mxVnjJaqa4d7/un1RB2KVpYLlmGdCUBVDQ1KLrWkraB7/opJZazuqnnWS3tu4hYEt/b+iXZ/tBtMrSFvEg==",
+      "integrity": "sha512-uSv8yR7boQhY1Oi7b2XevDo/rFm26lylNo6++hi4zBHFRFxDJb4wvkIBggS6oMts06atxZz5n4fhk3yAPk0K9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "react-native-device-info": "^14.0.0",

--- a/exampleReactNative/package-lock.json
+++ b/exampleReactNative/package-lock.json
@@ -10757,7 +10757,7 @@
     "node_modules/react-native-mtoken-sdk": {
       "version": "0.1.0",
       "resolved": "file:../build/react-native/react-native-mtoken-sdk-0.1.0.tgz",
-      "integrity": "sha512-lCu47ydX++QitHP+DOb5QftnG71DKdP1QNbalC+qix+Gggsu+2kbjTBwgkjC4fFG1FTCOBlqfoq9M9uYxaAQhQ==",
+      "integrity": "sha512-qcR4mxVnjJaqa4d7/un1RB2KVpYLlmGdCUBVDQ1KLrWkraB7/opJZazuqnnWS3tu4hYEt/b+iXZ/tBtMrSFvEg==",
       "license": "Apache-2.0",
       "dependencies": {
         "react-native-device-info": "^14.0.0",

--- a/exampleReactNative/src/tests/TestSuite_Integration.ts
+++ b/exampleReactNative/src/tests/TestSuite_Integration.ts
@@ -48,13 +48,13 @@ export class TestSuite_Integration extends TestSuite {
     }
 
     async testList() {
-        await this.mtoken.operations.pendingList()
+        await this.mtoken.operations.getOperations()
     }
 
     async testApprovePayment() {
         await this.utils.createOperation()
         
-        const operations = (await this.mtoken.operations.pendingList()).responseObject!!
+        const operations = (await this.mtoken.operations.getOperations()).responseObject!!
 
         this.assertEquals(operations.length, 1, "Missing operation")
 
@@ -88,7 +88,7 @@ export class TestSuite_Integration extends TestSuite {
 
     async testRejectPayment() {
         const op = await this.utils.createOperation()
-        const operations = await this.mtoken.operations.pendingList()
+        const operations = await this.mtoken.operations.getOperations()
         const opFromList = operations.responseObject!!.find( it => it.id == op.operationId )
         if (opFromList == undefined) {
             this.fail("Operation was not in the list")
@@ -189,7 +189,7 @@ export class TestSuite_Integration extends TestSuite {
 
         tempMtoken = this.powerAuth.createWultraMobileToken(undefined, expectedDefaultUserAgentProductName)
 
-        await tempMtoken.operations.pendingList( request => {
+        await tempMtoken.operations.getOperations( request => {
             const headers = request.headers as Headers
             this.assertTrue(headers.get("user-agent")!!.startsWith(expectedDefaultUserAgentProductName), `user-agent should start with ${expectedDefaultUserAgentProductName}`)
             return request
@@ -209,7 +209,7 @@ export class TestSuite_Integration extends TestSuite {
 
         tempMtoken = this.powerAuth.createWultraMobileToken(undefined, WMTUserAgent.SYSTEM_DEFAULT)
 
-        await tempMtoken.operations.pendingList( request => {
+        await tempMtoken.operations.getOperations( request => {
             const headers = request.headers as Headers
             this.assertEquals(headers.get("user-agent"), undefined)
             return request
@@ -222,15 +222,15 @@ export class TestSuite_Integration extends TestSuite {
         const cs = "cs"
 
         // set eng lang
-        this.mtoken.operations.acceptLanguage = en
-        await this.mtoken.operations.pendingList( request => {
+        this.mtoken.setAcceptLanguage(en)
+        await this.mtoken.operations.getOperations( request => {
             const headers = request.headers as Headers
             this.assertEquals(headers.get("accept-language")!!, en)
             return request
         })
 
         // set czech lang
-        this.mtoken.inbox.acceptLanguage = cs
+        this.mtoken.setAcceptLanguage(cs)
         await this.mtoken.inbox.getUnreadCount( request => {
             const headers = request.headers as Headers
             this.assertEquals(headers.get("accept-language"), cs)

--- a/exampleReactNative/src/tests/TestSuite_Integration.ts
+++ b/exampleReactNative/src/tests/TestSuite_Integration.ts
@@ -72,7 +72,7 @@ export class TestSuite_Integration extends TestSuite {
     async testRepeatedApprovePayment() {
         const op = await this.utils.createOperation()
         
-        const operation = (await this.mtoken.operations.detail(op.operationId)).responseObject!!
+        const operation = (await this.mtoken.operations.getDetail(op.operationId)).responseObject!!
 
         // authorize the operation
         const auth = PowerAuthAuthentication.password(this.pin)
@@ -101,7 +101,7 @@ export class TestSuite_Integration extends TestSuite {
         // lets create 1 operation and leave it in the state of "pending"
         const op = await this.utils.createOperation()
         const auth = PowerAuthAuthentication.password(this.pin)
-        const history = await this.mtoken.operations.history(auth)
+        const history = await this.mtoken.operations.getHistory(auth)
         this.assertNotNull(history.responseObject)
         const opRecord = history.responseObject!!.find( it => it.id == op.operationId )
         this.assertNotNull(opRecord)
@@ -136,7 +136,7 @@ export class TestSuite_Integration extends TestSuite {
 
     async testDetail() {
         const op = await this.utils.createNonPersonalizedPACOperation()
-        const operation = await this.mtoken.operations.detail(op.operationId)
+        const operation = await this.mtoken.operations.getDetail(op.operationId)
         this.assertNotNull(operation, "Failed to create & get the operation")
         this.assertEquals(op.operationId, operation.responseObject!!.id, "Operations ids are not equal")
     }
@@ -172,7 +172,7 @@ export class TestSuite_Integration extends TestSuite {
         // cancel the operation
         await this.utils.cancelOperation(op.operationId, cancelReason)
 
-        const operations = (await this.mtoken.operations.history(PowerAuthAuthentication.password(this.pin))).responseObject
+        const operations = (await this.mtoken.operations.getHistory(PowerAuthAuthentication.password(this.pin))).responseObject
         this.assertNotNull(operations, "Operations not retrieved")
         const opRecord = operations!!.find( it => it.id == op.operationId)
         this.assertNotNull(opRecord)
@@ -181,29 +181,35 @@ export class TestSuite_Integration extends TestSuite {
 
     async testTestUserAgents() {
 
+        let tempMtoken: WultraMobileToken
         const expectedDefaultUserAgentProductName = "MobileTokenJS"
         const testUserAgent = "test-agent"
 
-        // test default behavior (libraryDefault)
-        this.mtoken.setUserAgent(WMTUserAgent.LIBRARY_DEFAULT)
-        await this.mtoken.operations.pendingList( request => {
+        // Test default behavior (libraryDefault)
+
+        tempMtoken = this.powerAuth.createWultraMobileToken(undefined, expectedDefaultUserAgentProductName)
+
+        await tempMtoken.operations.pendingList( request => {
             const headers = request.headers as Headers
             this.assertTrue(headers.get("user-agent")!!.startsWith(expectedDefaultUserAgentProductName), `user-agent should start with ${expectedDefaultUserAgentProductName}`)
             return request
         })
 
-        // test custom user agent
-        this.mtoken.setUserAgent(testUserAgent)
-        await this.mtoken.inbox.unreadCount( request => {
+        // Test custom user agent
+
+        tempMtoken = this.powerAuth.createWultraMobileToken(undefined, testUserAgent)
+
+        await tempMtoken.inbox.getUnreadCount( request => {
             const headers = request.headers as Headers
             this.assertEquals(headers.get("user-agent"), testUserAgent)
             return request
         })
 
+        // Test system default (should be undefined in the request)
 
-        // test system default (should be undefined in the request)
-        this.mtoken.setUserAgent(WMTUserAgent.SYSTEM_DEFAULT)
-        await this.mtoken.operations.pendingList( request => {
+        tempMtoken = this.powerAuth.createWultraMobileToken(undefined, WMTUserAgent.SYSTEM_DEFAULT)
+
+        await tempMtoken.operations.pendingList( request => {
             const headers = request.headers as Headers
             this.assertEquals(headers.get("user-agent"), undefined)
             return request
@@ -216,7 +222,7 @@ export class TestSuite_Integration extends TestSuite {
         const cs = "cs"
 
         // set eng lang
-        this.mtoken.setAcceptLanguage(en)
+        this.mtoken.operations.acceptLanguage = en
         await this.mtoken.operations.pendingList( request => {
             const headers = request.headers as Headers
             this.assertEquals(headers.get("accept-language")!!, en)
@@ -224,8 +230,8 @@ export class TestSuite_Integration extends TestSuite {
         })
 
         // set czech lang
-        this.mtoken.setAcceptLanguage(cs)
-        await this.mtoken.inbox.unreadCount( request => {
+        this.mtoken.inbox.acceptLanguage = cs
+        await this.mtoken.inbox.getUnreadCount( request => {
             const headers = request.headers as Headers
             this.assertEquals(headers.get("accept-language"), cs)
             return request

--- a/exampleReactNative/src/tests/TestSuite_IntegrationInbox.ts
+++ b/exampleReactNative/src/tests/TestSuite_IntegrationInbox.ts
@@ -61,13 +61,13 @@ export class TestSuite_IntegrationInbox extends TestSuite {
         this.assertEquals(messagesToTest, await this.fetchUnreadMessagesCount())
 
         // Read first page
-        const messagesList = (await this.mtoken.inbox.list(0, 50, false)).responseObject
+        const messagesList = (await this.mtoken.inbox.getMessageList(0, 50, false)).responseObject
         this.assertNotNull(messagesList)
         this.compareMessages(messages, messagesList!!)
 
         // Now read first message's detail
         const firstMessage = messages[0]
-        const detail = (await this.mtoken.inbox.detail(firstMessage.id)).responseObject!!
+        const detail = (await this.mtoken.inbox.getMessageDetail(firstMessage.id)).responseObject!!
 
         this.assertEquals(firstMessage.id, detail.id)
         this.assertEquals(firstMessage.subject, detail.subject)
@@ -81,7 +81,7 @@ export class TestSuite_IntegrationInbox extends TestSuite {
     async testMarkMessageRead() {
         const count = 4
         const messages = await this.utils.createInboxMessages(count)
-        const receivedMessages = (await this.mtoken.inbox.list(0, 50, false)).responseObject!!
+        const receivedMessages = (await this.mtoken.inbox.getMessageList(0, 50, false)).responseObject!!
 
         this.compareMessages(messages, receivedMessages)
 
@@ -91,13 +91,13 @@ export class TestSuite_IntegrationInbox extends TestSuite {
         this.assertEquals(markRead.status, "OK")
 
         // Now get message detail
-        const messageDetail = await this.mtoken.inbox.detail(messageId)
+        const messageDetail = await this.mtoken.inbox.getMessageDetail(messageId)
         this.assertNotNull(messageDetail.responseObject)
         this.assertTrue(messageDetail.responseObject!!.read)
     }
 
     private async fetchUnreadMessagesCount(): Promise<number> {
-        let resp = await this.mtoken.inbox.unreadCount()
+        let resp = await this.mtoken.inbox.getUnreadCount()
         return resp.responseObject!!.countUnread
     }
 

--- a/exampleReactNative/src/tests/utils/IntegrationUtils.ts
+++ b/exampleReactNative/src/tests/utils/IntegrationUtils.ts
@@ -88,7 +88,7 @@ export class IntegrationUtils {
 
         return {
             powerauth: pa,
-            mtoken: new WultraMobileToken(pa, this.enrollmentUrl)
+            mtoken: pa.createWultraMobileToken()
         }
     }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,7 +134,7 @@ const sdkVersion = require('./package.json').version
     // create typings file
     const createCDVDtsTask = () =>
         gulp
-            .src([`${CDV_tempDir}/src/WultraMobileToken.ts`, `${CDV_tempDir}/src/WMT*.ts`, `${CDV_tempDir}/src/*/**.ts`])
+            .src([`${CDV_tempDir}/src/PWAExtension.ts`, `${CDV_tempDir}/src/WultraMobileToken.ts`, `${CDV_tempDir}/src/WMT*.ts`, `${CDV_tempDir}/src/*/**.ts`])
             .pipe(ts({ declaration: true, emitDeclarationOnly: true }))
             .pipe(concat(`typings.d.ts`))
             .pipe(stripImportExport()) // strim app all import/export

--- a/src/PWAExtension.ts
+++ b/src/PWAExtension.ts
@@ -1,0 +1,14 @@
+import { PowerAuth } from "react-native-powerauth-mobile-sdk";
+import { WultraMobileToken } from "./WultraMobileToken";
+import { WMTUserAgent } from "./networking/WMTNetworking";
+
+// TODO test cross-compilation to vanilla & CDV integration. Include in int tests. Include in docs.
+declare module "react-native-powerauth-mobile-sdk" {
+    interface PowerAuth {
+        createWultraMobileToken(acceptLanguage?: string, userAgent?: WMTUserAgent): WultraMobileToken
+    }
+}
+
+PowerAuth.prototype.createWultraMobileToken = function (acceptLanguage?: string, userAgent?: WMTUserAgent) {
+    return new WultraMobileToken(this, acceptLanguage, userAgent)
+}

--- a/src/PWAExtension.ts
+++ b/src/PWAExtension.ts
@@ -1,14 +1,52 @@
-import { PowerAuth } from "react-native-powerauth-mobile-sdk";
-import { WultraMobileToken } from "./WultraMobileToken";
-import { WMTUserAgent } from "./networking/WMTNetworking";
+import { PowerAuth } from "react-native-powerauth-mobile-sdk"
+import { WultraMobileToken } from "./WultraMobileToken"
+import { WMTUserAgent } from "./networking/WMTNetworking"
 
-// TODO test cross-compilation to vanilla & CDV integration. Include in int tests. Include in docs.
 declare module "react-native-powerauth-mobile-sdk" {
-    interface PowerAuth {
-        createWultraMobileToken(acceptLanguage?: string, userAgent?: WMTUserAgent): WultraMobileToken
+    export interface PowerAuth {
+
+        /**
+         * Creates Wultra Mobile Token services from on top of the `PowerAuthSDK`.
+         * URL from the `PowerAuthSDK` instance is used for services.
+         *
+         * `PowerAuthSDK` instance needs to be activated when calling any method of this class; otherwise, an error will be thrown.
+         * @param acceptLanguage Optionally sets the accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+         *                       The default value is "en".
+         *                       The value can be further modified in the each service object individualy.
+         *                       Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+         *                       Response texts are based on this setting. For example when "de" is set, server
+         *                       will return operation texts in german (if available).
+         * @param userAgent Optionally sets the User agent that will be used in a HTTP hader.
+         *                  Note that user-agent can be overriden by request processor in each API call.
+         * @returns Mobile Token SDK main wrapper.
+         */
+        createWultraMobileToken(
+            acceptLanguage?: string,
+            userAgent?: WMTUserAgent | string
+        ): WultraMobileToken
     }
 }
 
-PowerAuth.prototype.createWultraMobileToken = function (acceptLanguage?: string, userAgent?: WMTUserAgent) {
+/**
+ * Creates Wultra Mobile Token services from on top of the `PowerAuthSDK`.
+ * URL from the `PowerAuthSDK` instance is used for services.
+ *
+ * `PowerAuthSDK` instance needs to be activated when calling any method of this class; otherwise, an error will be thrown.
+ * @param acceptLanguage Optionally sets the accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+ *                       The default value is "en".
+ *                       The value can be further modified in the each service object individualy.
+ *                       Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+ *                       Response texts are based on this setting. For example when "de" is set, server
+ *                       will return operation texts in german (if available).
+ * @param userAgent Optionally sets the User agent that will be used in a HTTP hader.
+ *                  Note that user-agent can be overriden by request processor in each API call.
+ * @returns Mobile Token SDK main wrapper.
+ */
+PowerAuth.prototype.createWultraMobileToken = function (
+    acceptLanguage?: string,
+    userAgent?: WMTUserAgent | string
+) {
     return new WultraMobileToken(this, acceptLanguage, userAgent)
 }
+
+export {}

--- a/src/WMTException.ts
+++ b/src/WMTException.ts
@@ -17,9 +17,9 @@
 /** Possible logic errors during the API calls. */
 export class WMTException {
 
-    /** Description of the Exception */
+    /** Description of the Exception. */
     description: string
-    /** Optional additional data that helps with the exception */
+    /** Optional additional data that helps with the exception. */
     additionalData?: any
     
     constructor(description: string, additionalData?: any) {

--- a/src/WMTLogger.ts
+++ b/src/WMTLogger.ts
@@ -35,12 +35,13 @@ export enum WMTLoggerVerbosity {
 }
 
 /**
- * Mobile Token logging utility
+ * Mobile Token logging utility.
  */
 export class WMTLogger {
 
-    /** Which level of logs (and lower) should be logged into the console. Default value is `WARN` */
+    /** Which level of logs (and lower) should be logged into the console. Default value is `WARN`. */
     public static verbosity: WMTLoggerVerbosity = WMTLoggerVerbosity.WARN
+
     /** Include time in the logs? */
     public static includeTime: boolean = true
 

--- a/src/WMTPlatformUtils.ts
+++ b/src/WMTPlatformUtils.ts
@@ -19,6 +19,7 @@ import { WMT_SDK_VERSION } from "./WMTSDKVersion"
 import { Platform } from "react-native"
 import { WMTLogger } from "./WMTLogger"
 
+/* @internal */
 export class WMTPlatformUtils {
 
     static getPlatform():  "ios" | "android" {

--- a/src/WultraMobileToken.ts
+++ b/src/WultraMobileToken.ts
@@ -18,77 +18,63 @@ import { WMTOperations } from './operations/WMTOperations'
 import { PowerAuth } from 'react-native-powerauth-mobile-sdk'
 import { WMTPush } from './push/WMTPush'
 import { WMTInbox } from './inbox/WMTInbox'
-import type { WMTUserAgent } from './networking/WMTNetworking'
+import { WMTUserAgent } from './networking/WMTNetworking'
 import { WMTLogger } from './WMTLogger'
 
 /**
- * MobileToken class exposes API that enables to fetch, authorize or reject basic
- * operations created in the PowerAuth stack.
+ * MobileToken class exposes APIs that enable:
+ *  Fetching, authorizing or rejecting basic
+ *  operations created in the PowerAuth stack.
+ *  Push notifications enrollment.
+ *  Inbox message management.
  */
 export class WultraMobileToken {
 
     /** Operations manager. Use for fetching pending list, approving the operations etc. */
     operations: WMTOperations
+
     /** Push manager for registering the device to recieve PowerAuth push notification for given PowerAuth activation. */
     push: WMTPush
+
     /** Inbox manager - recieve message to communicate with the user. */
     inbox: WMTInbox
 
     /**
      * 
      * @param powerAuth PowerAuth instance. Needs to be activated when calling any method of this class - othewise error will be thrown.
-     * @param baseURL BaseURL of the server. If not provided, same URL as for PowerAuth it used.
-     * @param pushBaseURL In case that the push server is on different URL.
-     *                    This is a rare scenario which doesn't happen in regular setup.
-     *                    When not set, baseURL is used.
-     * @param inboxBaseURL In case that the inbox server is on different URL.
-     *                     This is a rare scenario which doesn't happen in regular setup.
-     *                     When not set, baseURL is used.
+     * @param acceptLanguage Optionally sets the accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+     *                       The default value is "en".
+     *                       The value can be further modified in the each service object individualy.
+     *                       Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+     *                       Response texts are based on this setting. For example when "de" is set, server
+     *                       will return operation texts in german (if available).
+     * @param userAgent Optionally sets the User agent that will be used in a HTTP hader. 
+     *                  Note that user-agent can be overriden by request processor in each API call.
      */
-    constructor(powerAuth: PowerAuth, baseURL?: string, pushBaseURL?: string, inboxBaseURL?: string) {
+    constructor(powerAuth: PowerAuth, acceptLanguage?: string, userAgent?: WMTUserAgent | string) {
 
-        let enrollmentURL = baseURL ?? powerAuth.configuration?.baseEndpointUrl ?? ""
-        let pushURL = pushBaseURL ?? enrollmentURL
-        let inboxURL = inboxBaseURL ?? enrollmentURL
+        // Retrieve the base URL and instantiate mtoken services.
+        let baseURL = powerAuth.configuration?.baseEndpointUrl ?? ""
 
-        this.operations = new WMTOperations(powerAuth, enrollmentURL)
-        this.push = new WMTPush(powerAuth, pushURL)
-        this.inbox = new WMTInbox(powerAuth, inboxURL)
+        this.operations = new WMTOperations(powerAuth, baseURL)
+        this.push = new WMTPush(powerAuth, baseURL)
+        this.inbox = new WMTInbox(powerAuth, baseURL)
 
-        WMTLogger.debug("Mobile Token object created with:")
-        WMTLogger.debug(" - baseURL: " + enrollmentURL)
-        WMTLogger.debug(" - pushURL: " + pushURL)
-        WMTLogger.debug(" - inboxURL: " + inboxURL)
-    }
-
-    /**
-     * Sets accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
-     * 
-     * The value can be further modified in the each object individualy.
-     * 
-     * Default value is "en".
-     * 
-     * 
-     * Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
-     * Response texts are based on this setting. For example when "de" is set, server
-     * will return operation texts in german (if available).
-     */
-    setAcceptLanguage(lang: string) {
+        // Set the accept language properties.
+        let lang = acceptLanguage ?? "en"
         this.operations.acceptLanguage = lang
         this.push.acceptLanguage = lang
         this.inbox.acceptLanguage = lang
-        WMTLogger.info(`accent language set to ${lang}`)
-    }
 
-    /** 
-     * User agent that will be used in a HTTP hader. 
-     * 
-     * Note that user-agent can be overriden by request processor in each API call.
-     */
-    setUserAgent(userAgent: WMTUserAgent | string) {
-        this.operations.userAgent = userAgent
-        this.push.userAgent = userAgent
-        this.inbox.userAgent = userAgent
-        WMTLogger.info(`User-Agent set to ${userAgent}`)
+        // Set the user agent properties.
+        let agent = userAgent ?? WMTUserAgent.LIBRARY_DEFAULT
+        this.operations.userAgent = agent
+        this.push.userAgent = agent
+        this.inbox.userAgent = agent
+
+        WMTLogger.debug("Mobile Token object created with:")
+        WMTLogger.debug(" - baseURL: " + baseURL)
+        WMTLogger.debug(" - acceptLanguage:" + lang)
+        WMTLogger.debug(" - userAgent: " + agent)
     }
 }

--- a/src/WultraMobileToken.ts
+++ b/src/WultraMobileToken.ts
@@ -50,11 +50,16 @@ export class WultraMobileToken {
      *                       will return operation texts in german (if available).
      * @param userAgent Optionally sets the User agent that will be used in a HTTP hader. 
      *                  Note that user-agent can be overriden by request processor in each API call.
+     * @throws Can throw when a null or invalid `baseEndpointUrl` is set in the `PowerAuth` instance.
      */
     constructor(powerAuth: PowerAuth, acceptLanguage?: string, userAgent?: WMTUserAgent | string) {
 
         // Retrieve the base URL and instantiate mtoken services.
-        let baseURL = powerAuth.configuration?.baseEndpointUrl ?? ""
+        let baseURL = powerAuth.configuration?.baseEndpointUrl
+
+        if (baseURL == null) {
+            throw new Error("Null base URL recieved from the PowerAuth instance.")
+        }
 
         this.operations = new WMTOperations(powerAuth, baseURL)
         this.push = new WMTPush(powerAuth, baseURL)
@@ -76,5 +81,23 @@ export class WultraMobileToken {
         WMTLogger.debug(" - baseURL: " + baseURL)
         WMTLogger.debug(" - acceptLanguage:" + lang)
         WMTLogger.debug(" - userAgent: " + agent)
+    }
+
+    /**
+     * Sets accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+     *
+     * The value can be further modified in the each object individualy.
+     *
+     * Default value is "en".
+     *
+     * Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+     * Response texts are based on this setting. For example when "de" is set, server
+     * will return operation texts in german (if available).
+     */
+    setAcceptLanguage(lang: string) {
+        this.operations.acceptLanguage = lang
+        this.push.acceptLanguage = lang
+        this.inbox.acceptLanguage = lang
+        WMTLogger.info(`accent language set to ${lang}`)
     }
 }

--- a/src/inbox/WMTInbox.ts
+++ b/src/inbox/WMTInbox.ts
@@ -20,7 +20,7 @@ import { type WMTInboxMessage } from "./WMTInboxMessage"
 import { type WMTInboxMessageDetail } from "./WMTInboxMessageDetail"
 import { PowerAuthAuthentication } from 'react-native-powerauth-mobile-sdk'
 
-/** Inbox handling. */
+/** Service that communicates with Inbox API that is managing user's inbox. */
 export class WMTInbox extends WMTNetworking {
 
     // name of the parsed fields that are expected to be the Date type.
@@ -32,7 +32,7 @@ export class WMTInbox extends WMTNetworking {
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
      * @returns Server response (with the unread count)
      */
-    async unreadCount(requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTInboxCount>> {
+    async getUnreadCount(requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTInboxCount>> {
         return await this.postSignedWithToken<WMTInboxCount>(
             { },
             PowerAuthAuthentication.possession(),
@@ -52,7 +52,7 @@ export class WMTInbox extends WMTNetworking {
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
      * @returns Server response (with the list of messages)
      */
-    async list(pageNumber: Number, pageSize: Number, onlyUnread: boolean, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTInboxMessage[]>> {
+    async getMessageList(pageNumber: Number, pageSize: Number, onlyUnread: boolean, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTInboxMessage[]>> {
         return await this.postSignedWithToken<WMTInboxMessage[]>(
             { requestObject: { page: pageNumber, size: pageSize, onlyUnread: onlyUnread } },
             PowerAuthAuthentication.possession(),
@@ -71,7 +71,7 @@ export class WMTInbox extends WMTNetworking {
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
      * @returns Server response (with the message detail)
      */
-    async detail(messageId: string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTInboxMessageDetail>> {
+    async getMessageDetail(messageId: string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTInboxMessageDetail>> {
         return await this.postSignedWithToken<WMTInboxMessageDetail>(
             { requestObject: { id: messageId } },
             PowerAuthAuthentication.possession(),

--- a/src/inbox/WMTInboxCount.ts
+++ b/src/inbox/WMTInboxCount.ts
@@ -14,7 +14,7 @@
 // and limitations under the License.
 //
 
-/** Structure contains information about unread messages in inbox. */
+/** Model containing the information about unread messages in inbox. */
 export interface WMTInboxCount {
     /** Number of unread messages in inbox. */
     countUnread: number

--- a/src/inbox/WMTInboxMessage.ts
+++ b/src/inbox/WMTInboxMessage.ts
@@ -14,7 +14,7 @@
 // and limitations under the License.
 //
 
-/** Structure contains information about message in inbox. */
+/** Model containing the information about a message in inbox. */
 export interface WMTInboxMessage {
     /** Message's identifier. */
     id: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,3 +45,6 @@ export * from './networking/WMTNetworking'
 // INTERNAL
 export * from './WMTPlatformUtils'
 export * from './WMTSDKVersion'
+
+// PWA MTOKEN INSTANTIATION
+export * from './PWAExtension'

--- a/src/networking/WMTNetworking.ts
+++ b/src/networking/WMTNetworking.ts
@@ -25,8 +25,31 @@ export type WMTRequestProcessor = (request: RequestInit) => RequestInit
 /** @internal */
 export class WMTNetworking {
 
-    /** @internal */
-    acceptLanguage = "en"
+    private _acceptLanguage = "en"
+
+    /**
+     * Returns accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+     *
+     */
+    get acceptLanguage() {
+        return this._acceptLanguage
+    }
+
+    /**
+     * Sets accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
+     *
+     * Default value is "en".
+     *
+     *
+     * Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+     * Response texts are based on this setting. For example when "de" is set, server
+     * will return operation texts in german (if available).
+     */
+    set acceptLanguage(lang: string) {
+        this._acceptLanguage = lang
+        WMTLogger.info(`Accept language set to ${lang}.`)
+    }
+
     /** @internal */
     userAgent: WMTUserAgent | string = WMTUserAgent.LIBRARY_DEFAULT
 
@@ -167,7 +190,8 @@ export enum WMTUserAgent {
     /** 
      * Default value provided by the libary. 
      * 
-     * Example value: `TODO`
+     * Example value (on an Apple device):
+     * `MobileTokenJS/1.0.0 com.yourcompany.yourappid/1.0.0 (Apple; iOS/18.2; iPhone16)`.
      */
     LIBRARY_DEFAULT = "LIBRARY_DEFAULT",
 
@@ -189,7 +213,7 @@ export interface WMTResponse<T> {
     responseObject?: T
 } 
   
-  /** Error object when error on the server happens. */
+/** Error object when error on the server happens. */
 export interface WMTResponseError {
     code: WMTKnownRestApiError | string
     message: string

--- a/src/networking/WMTNetworking.ts
+++ b/src/networking/WMTNetworking.ts
@@ -22,7 +22,6 @@ import { WMTPlatformUtils } from "../WMTPlatformUtils"
 
 export type WMTRequestProcessor = (request: RequestInit) => RequestInit
 
-/** @internal */
 export class WMTNetworking {
 
     private _acceptLanguage = "en"
@@ -39,7 +38,6 @@ export class WMTNetworking {
      * Sets accept language for the outgoing requests headers for `operations`, `push` and `inbox` objects.
      *
      * Default value is "en".
-     *
      *
      * Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
      * Response texts are based on this setting. For example when "de" is set, server

--- a/src/operations/WMTOperations.ts
+++ b/src/operations/WMTOperations.ts
@@ -44,13 +44,13 @@ export class WMTOperations extends WMTNetworking {
     }
 
     /**
-     * Retrieves operation detail based on operation ID
+     * Retrieves operation detail based on operation ID.
      * 
-     * @param operationId ID of the operation
+     * @param operationId ID of the operation.
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
      * @returns Server response (with operation detail)
      */
-    async detail(operationId: string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation>> {
+    async getDetail(operationId: string, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation>> {
         return await this.postSignedWithToken<WMTUserOperation>(
             { requestObject: { id: operationId } },
             PowerAuthAuthentication.possession(),
@@ -63,13 +63,13 @@ export class WMTOperations extends WMTNetworking {
     }
 
     /**
-     * Retrieves the history of user operations.
+     * Retrieves the history of user operations with their current status.
      * 
-     * @param authentication Authentication object
+     * @param authentication A multi-factor authentication object for signing. 2FA should be used (password or biometrics).
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
-     * @returns Server response (with list of operations).
+     * @returns Server response (with the list of operations).
      */
-    async history(authentication: PowerAuthAuthentication, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>> {
+    async getHistory(authentication: PowerAuthAuthentication, requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>> {
         return await this.postSigned<WMTUserOperation[]>(
             {},
             authentication,
@@ -84,8 +84,8 @@ export class WMTOperations extends WMTNetworking {
     /**
      * Authorize operation with given PowerAuth authentication object.
      * 
-     * @param operation Operation to authorize
-     * @param authentication Authentication object
+     * @param operation Operation to authorize.
+     * @param authentication Authentication object.
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
      * @returns Server response
      */
@@ -126,6 +126,9 @@ export class WMTOperations extends WMTNetworking {
     /**
      * Sign offline QR operation with provided authentication.
      * 
+     * Note that the operation will be signed even if the authentication object is
+     * not valid as it cannot be verified on the server.
+     *
      * @param operation Operation to approve
      * @param authentication Authentication object
      * @param uriId Custom signature URI ID of the operation. Use URI ID under which the operation was
@@ -137,9 +140,9 @@ export class WMTOperations extends WMTNetworking {
     }
 
     /**
-     * Assigns the 'non-personalized' operation to the user
+     * Assigns the 'non-personalized' operation to the user.
      * 
-     * @param operationId ID of the operation.
+     * @param operationId ID of the operation which will be claimed to belong to the user.
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
      * @returns Server response (with operation detail)
      */

--- a/src/operations/WMTOperations.ts
+++ b/src/operations/WMTOperations.ts
@@ -26,12 +26,12 @@ export class WMTOperations extends WMTNetworking {
     private jsonDateFields = [ "operationExpires", "operationCreated", "timestampReceived" ]
 
     /**
-    * Retrieves user operations that are pending approval.
+    * Retrieves user operations.
     * 
     * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
     * @returns Server response (with list of operations).
     */
-    async pendingList(requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>> {
+    async getOperations(requestProcessor?: WMTRequestProcessor): Promise<WMTResponse<WMTUserOperation[]>> {
         return await this.postSignedWithToken<WMTUserOperation[]>(
             {},
             PowerAuthAuthentication.possession(),

--- a/src/operations/WMTOperations.ts
+++ b/src/operations/WMTOperations.ts
@@ -85,7 +85,7 @@ export class WMTOperations extends WMTNetworking {
      * Authorize operation with given PowerAuth authentication object.
      * 
      * @param operation Operation to authorize.
-     * @param authentication Authentication object.
+     * @param authentication A multi-factor authentication object for signing. 2FA should be used (password or biometrics).
      * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
      * @returns Server response
      */
@@ -130,7 +130,7 @@ export class WMTOperations extends WMTNetworking {
      * not valid as it cannot be verified on the server.
      *
      * @param operation Operation to approve
-     * @param authentication Authentication object
+     * @param authentication A multi-factor authentication object for signing. 2FA should be used (password or biometrics).
      * @param uriId Custom signature URI ID of the operation. Use URI ID under which the operation was
      * created on the server. Default value is `/operation/authorize/offline`.
      * @returns 

--- a/src/operations/WMTPACUtils.ts
+++ b/src/operations/WMTPACUtils.ts
@@ -16,18 +16,18 @@
 
 import { WMTLogger } from "../WMTLogger"
 
-/** Data payload which is returned from the parser */
+/** Data payload which is returned from the parser. */
 export interface WMTPACData {
 
-    /** The ID of the operation associated with the TOTP */
+    /** The ID of the operation associated with the TOTP. */
     oid: string
 
-    /** The actual Time-based one time password (proximity OTP) */
+    /** The actual Time-based one time password (proximity OTP). */
     potp?: string
 }
 
 /**
- * Utility class used for handling Proximity Anti-fraud Checks
+ * Utility class used for handling Proximity Anti-fraud Checks.
  */
 export class WMTPACUtils {
 
@@ -72,9 +72,9 @@ export class WMTPACUtils {
     /** 
      * Method accepts scanned code as a String and returns PAC data or throws an exception.
      * 
-     * @param code Code retrieved from the QR
-     * @returns Data with parsed Proximity Antofraud Check data
-     * @throws Exception when cannot be parsed
+     * @param code Code retrieved from the QR.
+     * @returns Data with parsed Proximity Antofraud Check data.
+     * @throws Exception when cannot be parsed.
      */
     static parseQRCode(code: string): WMTPACData {
         

--- a/src/operations/WMTQROperation.ts
+++ b/src/operations/WMTQROperation.ts
@@ -17,36 +17,36 @@
 /** The `QROperationData` contains data operation data parsed from QR code. */
 export interface WMTQROperation {
     
-    /** Operation's identifier */
+    /** Operation's identifier. */
     operationId: string
     
     /** Title associated with the operation. */
     title: string
     
-    /** Message associated with the operation */
+    /** Message associated with the operation. */
     message: string
     
-    /** Significant data fields associated with the operation */
+    /** Significant data fields associated with the operation. */
     operationData: WMTQROperationData
     
-    /** Nonce for offline signature calculation, in Base64 format */
+    /** Nonce for offline signature calculation, in Base64 format. */
     nonce: string
     
-    /** Flags associated with the operation */
+    /** Flags associated with the operation. */
     flags: WMTQROperationFlags
     
-    /** Additional Time-based one time password for proximity check */
+    /** Additional Time-based one time password for proximity check. */
     totp?: string
     
-    /** Data for signature validation */
+    /** Data for signature validation. */
     signedData: string
     
-    /** ECDSA signature calculated from `signedData`. String is in Base64 format */
+    /** ECDSA signature calculated from `signedData`. String is in Base64 format. */
     signature: WMTQROperationSignature
     
     /**
      * QR code uses a string in newer format that this class implements.
-     * This flag may be used as warning, presented in UI
+     * This flag may be used as warning, presented in UI.
      */
     isNewerFormat: boolean
 }
@@ -67,10 +67,10 @@ export interface WMTQROperationFlags {
 
 export interface WMTQROperationData {
 
-    /** Version of form data */
+    /** Version of form data. */
     version: WMTQROperationDataVersion
 
-    /** Template identifier (0 .. 99 in v1) */
+    /** Template identifier (0 .. 99 in v1). */
     templateId: Number
 
     /** Array with form fields. Version v1 supports up to 5 fields. */
@@ -81,9 +81,9 @@ export interface WMTQROperationData {
 }
 
 export enum WMTQROperationDataVersion {
-    /** First version of operation data */
+    /** First version of operation data. */
     V1,
-    /** Type representing all newer versions of operation data (for forward compatibility) */
+    /** Type representing all newer versions of operation data (for forward compatibility). */
     VX
 }
 
@@ -97,23 +97,23 @@ export class WMTQROperationDataVersionUtil {
 }
 
 export enum WMTQROperationDataFieldType {
-    /** Empty field for optional and not used fields */
+    /** Empty field for optional and not used fields. */
     EMPTY,
-    /** Field is of type `AmountField` */
+    /** Field is of type `AmountField`. */
     AMOUNT,
-    /** Field is of type `AccountField` */
+    /** Field is of type `AccountField`. */
     ACCOUNT,
-    /** Field is of type `AnyAccountField` */
+    /** Field is of type `AnyAccountField`. */
     ANY_ACCOUNT,
-    /** Field is of type `DateField` */
+    /** Field is of type `DateField`. */
     DATE,
-    /** Field is of type `ReferenceField` */
+    /** Field is of type `ReferenceField`. */
     REFERENCE,
-    /** Field is of type `NoteField` */
+    /** Field is of type `NoteField`. */
     NOTE,
-    /** Field is of type TextField`` */
+    /** Field is of type `TextField`. */
     TEXT,
-    /** Field is of type `FallbackField` */
+    /** Field is of type `FallbackField`. */
     FALLBACK
 }
 
@@ -121,7 +121,7 @@ export interface WMTQROperationDataField {
     type: WMTQROperationDataFieldType
 }
 
-/** Amount with currency */
+/** Amount with currency. */
 export class WMTAmountField implements WMTQROperationDataField {
     type = WMTQROperationDataFieldType.AMOUNT
     amount: Number
@@ -133,7 +133,7 @@ export class WMTAmountField implements WMTQROperationDataField {
     }
 }
 
-/** Account in IBAN format, with optional BIC */
+/** Account in IBAN format, with optional BIC. */
 export class WMTAccountField implements WMTQROperationDataField { 
     type = WMTQROperationDataFieldType.ACCOUNT
     iban: string
@@ -145,7 +145,7 @@ export class WMTAccountField implements WMTQROperationDataField {
     }
 }
 
-/** Account in arbitrary textual format */
+/** Account in arbitrary textual format. */
 export class WMTAnyAccountField implements WMTQROperationDataField {
     type = WMTQROperationDataFieldType.ANY_ACCOUNT
     account: string
@@ -155,7 +155,7 @@ export class WMTAnyAccountField implements WMTQROperationDataField {
     }
 }
 
-/** Date field */
+/** Date field. */
 export class WMTDateField implements WMTQROperationDataField {
     type = WMTQROperationDataFieldType.DATE
     date: Date
@@ -165,7 +165,7 @@ export class WMTDateField implements WMTQROperationDataField {
     }
 }
 
-/** Reference field */
+/** Reference field. */
 export class WMTReferenceField implements WMTQROperationDataField {
     type = WMTQROperationDataFieldType.REFERENCE
     text: string
@@ -175,7 +175,7 @@ export class WMTReferenceField implements WMTQROperationDataField {
     }
 }
 
-/** Note Field */
+/** Note field. */
 export class WMTNoteField implements WMTQROperationDataField {
     type = WMTQROperationDataFieldType.NOTE
     text: string
@@ -185,7 +185,7 @@ export class WMTNoteField implements WMTQROperationDataField {
     }
 }
 
-/** Text Field */
+/** Text field. */
 export class WMTTextField implements WMTQROperationDataField {
     type = WMTQROperationDataFieldType.TEXT
     text: string
@@ -216,19 +216,19 @@ export interface WMTQROperationSignature {
     /** Defines which key has been used for ECDSA signature calculation. */
     signingKey: WMTSigningKey
 
-    /** Raw signature data */
+    /** Raw signature data. */
     signature: Buffer
 
-    /** Signature in Base64 format */
+    /** Signature in Base64 format. */
     signatureString: string
 }
 
-/** Defines which key was used for ECDSA signature calculation */
+/** Defines which key was used for ECDSA signature calculation. */
 export enum WMTSigningKey {
-    /** Master server key was used for ECDSA signature calculation */
+    /** Master server key was used for ECDSA signature calculation. */
     MASTER,
 
-    /** Personalized server's private key was used for ECDSA signature calculation */
+    /** Personalized server's private key was used for ECDSA signature calculation. */
     PERSONALIZED
 }
 

--- a/src/operations/WMTQROperationParser.ts
+++ b/src/operations/WMTQROperationParser.ts
@@ -20,14 +20,14 @@ import { Buffer } from "buffer"
 import { WMTLogger } from "../WMTLogger"
 
 /**
- * Parser for QR operation
+ * Parser for QR operation.
  */
 export class WMTQROperationParser {
 
-    // Minimum lines in input string supported by this parser
+    // Minimum lines in input string supported by this parser.
     private static readonly minimumAttributeFields = 7
 
-    // Current number of lines in input string, supported by this parser
+    // Current number of lines in input string, supported by this parser.
     private static readonly currentAttributeFields = 8
 
     // Maximum number of operation data fields supported in this version.
@@ -38,7 +38,7 @@ export class WMTQROperationParser {
     /**
      * Process loaded payload from a scanned offline QR.
      *
-     * @param string String parsed from QR code
+     * @param string String parsed from QR code.
      *
      * @throws MobileTokenException When there is no operation in provided string.
      * @return Parsed operation.
@@ -205,7 +205,8 @@ export class WMTQROperationParser {
     }
 
     /**
-     * Parses input string into array of Field enumerations. Returns nil if some field has
+     * Parses input string into array of Field enumerations.
+     * Throws a `WMTException` error if the resulting operation parses out with too many fields.
      */
     private static parseDataFields(fields: string[]): WMTQROperationDataField[] {
 

--- a/src/operations/WMTUserOperation.ts
+++ b/src/operations/WMTUserOperation.ts
@@ -26,7 +26,7 @@ import type { WMTUserOperationProximityCheck } from "./WMTUserOperationProximity
  */
 export interface WMTUserOperation extends WMTOnlineOperation {
 
-    /** Processing status of the operation */
+    /** Processing status of the operation. */
     status: "APPROVED" | "REJECTED" | "PENDING" | "CANCELED" | "EXPIRED" | "FAILED"
 
     /**
@@ -72,7 +72,7 @@ export interface WMTUserOperation extends WMTOnlineOperation {
     allowedSignatureType: WMTAllowedOperationSignature
     
     /**
-     * UI data to be shown
+     * UI data to be shown.
      *
      * Accompanying information about the operation additional UI which should be presented such as
      * Pre-Approval Screen or Post-Approval Screen
@@ -104,7 +104,7 @@ export interface WMTAllowedOperationSignature {
  */
 export interface WMTOperationFormData {
     
-    /** Title of the operation */
+    /** Title of the operation. */
     title: string
     
     /** Message for the user. */

--- a/src/operations/WMTUserOperationAttribute.ts
+++ b/src/operations/WMTUserOperationAttribute.ts
@@ -24,7 +24,7 @@ export interface WMTUserOperationAttribute {
 
     /** 
      * ID (type) of the label. This is highly depended on the backend
-     * and can be used to change the appearance of the label
+     * and can be used to change the appearance of the label.
      */
     id: string
 
@@ -37,27 +37,27 @@ export interface WMTUserOperationAttribute {
      */
     type: WMTAttributeType | string
     
-    /** Label value */ 
+    /** Label value. */ 
     label: string
 }
 
 /** Attribute type. Based on this type, proper class should be chosen for "deserialization". */
 export enum WMTAttributeType {
-    /** Amount, like "100.00 CZK" */
+    /** Amount, like "100.00 CZK." */
     AMOUNT            = "AMOUNT", 
-    /** Currency conversion, for example when changing money from USD to EUR */
+    /** Currency conversion, for example when changing money from USD to EUR. */
     AMOUNT_CONVERSION = "AMOUNT_CONVERSION",
-    /** Any key value pair */
+    /** Any key value pair. */
     KEY_VALUE          = "KEY_VALUE",
-    /** Just like KEY_VALUE, emphasizing that the value is a note or message */
+    /** Just like KEY_VALUE, emphasizing that the value is a note or message. */
     NOTE              = "NOTE",
-    /** Single highlighted text, written in a larger font, used as a section heading */
+    /** Single highlighted text, written in a larger font, used as a section heading. */
     HEADING           = "HEADING",
-    /** For image displaying */
+    /** For image displaying. */
     IMAGE            = "IMAGE"
 }
 
-/** Amount attribute is 1 row in operation, that represents "Payment Amount" */
+/** Amount attribute is 1 row in operation, that represents "Payment Amount". */
 export interface WMTOperationAttributeAmount extends WMTUserOperationAttribute {
     
     /**
@@ -70,9 +70,9 @@ export interface WMTOperationAttributeAmount extends WMTUserOperationAttribute {
     amountFormatted?: string
     
     /**
-     * Formatted currency to the locale based on acceptLanguage
+     * Formatted currency to the locale based on acceptLanguage.
      * 
-     * For example when the currency is CZK, this property will be "Kč"
+     * For example when the currency is CZK, this property will be "Kč".
      */
     currencyFormatted?: string
     
@@ -81,14 +81,14 @@ export interface WMTOperationAttributeAmount extends WMTUserOperationAttribute {
      */
     amount?: number
     
-    /** Currency */
+    /** Currency. */
     currency?: string
 
     /**
-     * Formatted value and currency to the locale based on acceptLanguage
+     * Formatted value and currency to the locale based on acceptLanguage.
      * 
      * Both amount and currency are formatted, String will show e.g. "€" in front of the amount
-     * or "EUR" behind the amount depending on the locale
+     * or "EUR" behind the amount depending on the locale.
      */
     valueFormatted?: string
 }
@@ -110,7 +110,7 @@ export interface WMTOperationAttributeHeading extends WMTUserOperationAttribute 
     
 }
 
-/** Image that might be "open" on tap/click. */
+/** Image that might be "opened" on tap/click. */
 export interface WMTOperationAttributeImage extends WMTUserOperationAttribute {
 
     /** Image thumbnail url to the public internet. */
@@ -118,16 +118,16 @@ export interface WMTOperationAttributeImage extends WMTUserOperationAttribute {
     
     /**
      * Full-size image that should be displayed on thumbnail click (when not null).
-     * Url to the public internet
+     * Url to the public internet.
      */
     originalUrl?: string
 }
 
-/** Conversion attribute is 1 row in operation, that represents "Money Conversion" */
+/** Conversion attribute is 1 row in operation, that represents "Money Conversion". */
 export interface WMTOperationAttributeAmountConversion extends WMTUserOperationAttribute {
     
     /**
-     * If the conversion is dynamic and the application should refresh it periodically
+     * If the conversion is dynamic and the application should refresh it periodically.
      * 
      * This is just a hint for the application UI. This SDK does not offer feature to periodically
      * refresh conversion rate.
@@ -143,27 +143,27 @@ export interface WMTOperationAttributeAmountConversion extends WMTUserOperationA
      */
     sourceAmountFormatted?: string 
     /**
-     * Formatted currency to the locale based on acceptLanguage
+     * Formatted currency to the locale based on acceptLanguage.
      * 
-     * For example when the currency is CZK, this property will be "Kč"
+     * For example when the currency is CZK, this property will be "Kč".
      */
     sourceCurrencyFormatted?: string
 
     /**
-     * Payment amount
+     * Payment amount.
      * 
      * Amount might not be precise (due to floating point conversion during deserialization from json)
-     * use amountFormatted property instead when available
+     * use amountFormatted property instead when available.
      */
     sourceAmount?: number
 
     /** Currency */
     sourceCurrency?: string
     /**
-     * Formatted currency and amount to the locale based on acceptLanguage
+     * Formatted currency and amount to the locale based on acceptLanguage.
      * 
      * Both amount and currency are formatted, String will show e.g. "€" in front of the amount
-     * or "EUR" behind the amount depending on locale
+     * or "EUR" behind the amount depending on locale.
      */
     sourceValueFormatted?: string
     
@@ -177,27 +177,27 @@ export interface WMTOperationAttributeAmountConversion extends WMTUserOperationA
     targetAmountFormatted?: string
 
     /**
-     * Formatted currency to the locale based on acceptLanguage
+     * Formatted currency to the locale based on acceptLanguage.
      * 
-     * For example when the currency is CZK, this property will be "Kč"
+     * For example when the currency is CZK, this property will be "Kč".
      */
     targetCurrencyFormatted?: string
     /**
-     * Payment amount
+     * Payment amount.
      * 
      * Amount might not be precise (due to floating point conversion during deserialization from json)
-     * use amountFormatted property instead when available
+     * use amountFormatted property instead when available.
      */
     targetAmount?: number
 
-    /** Currency */
+    /** Currency. */
     targetCurrency?: string
     
     /**
-     * Formatted currency and amount to the locale based on acceptLanguage
+     * Formatted currency and amount to the locale based on acceptLanguage.
      * 
      * Both amount and currency are formatted, String will show e.g. "€" in front of the amount
-     * or "EUR" behind the amount depending on locale
+     * or "EUR" behind the amount depending on locale.
      */
     targetValueFormatted?: string
 }

--- a/src/operations/WMTUserOperationProximityCheck.ts
+++ b/src/operations/WMTUserOperationProximityCheck.ts
@@ -14,13 +14,17 @@
 // and limitations under the License.
 //
 
+/**
+ * Object that is used to hold data about a proximity check.
+ * Data shall be assigned to the operation when obtained.
+ */
 export interface WMTUserOperationProximityCheck {
-    /** The actual Time-based one time password */
+    /** The actual Time-based one time password. */
     totp: string
 
-    /** Type of the Proximity check */
+    /** Type of the Proximity check. */
     type: "QR_CODE" | "DEEPLINK"
 
-    /** Timestamp when the operation was scanned (qrCode) or delivered to the device (deeplink) */
+    /** Timestamp when the operation was scanned (qrCode) or delivered to the device (deeplink). */
     timestampReceived: Date
 }

--- a/src/operations/WMTUserOperationUIData.ts
+++ b/src/operations/WMTUserOperationUIData.ts
@@ -16,20 +16,20 @@
 
 import type { WMTUserOperationAttribute } from "./WMTUserOperationAttribute"
 
-/** Additional UI data */
+/** Operation UI model that contains data for screens for pre and/or post approved operation. */
 export interface WMTUserOperationUIData {
 
-    /** Confirm and Reject buttons should be flipped both in position and style */
+    /** Confirm and Reject buttons should be flipped both in position and style. */
     flipButtons?: boolean
 
-    /** Block approval when on call (for example when on phone or skype call) */
+    /** Block approval when on call (for example when on phone or skype call). */
     blockApprovalOnCall?: boolean
 
-    /** UI for pre-approval operation screen */
+    /** UI for pre-approval operation screen. */
     preApprovalScreen?: WMTPreApprovalScreen
 
     /**
-     * UI for post-approval operation screen
+     * UI for post-approval operation screen.
      *
      * Type of PostApprovalScreen is presented with different classes based on its type (Starting with `PostApprovalScreen*`).
      * 
@@ -39,34 +39,34 @@ export interface WMTUserOperationUIData {
 }
 
 /**
- *  PreApprovalScreen contains data to be presented before approving operation
+ *  PreApprovalScreen contains data to be presented before approving operation.
  *
  * `type` define different kind of data which can be passed with operation
- *  and shall be displayed before operation is confirmed
+ *  and shall be displayed before operation is confirmed.
  */
 export interface WMTPreApprovalScreen {
     /**
-     * Type of PreApprovalScreen (`WARNING`, `INFO`, `QR_SCAN` - might be undefined for future compatibility)
+     * Type of PreApprovalScreen (`WARNING`, `INFO`, `QR_SCAN` - might be undefined for future compatibility).
      */
     type?: "INFO" | "WARNING" | "QR_SCAN" | "UNKNOWN"
 
     /**
-     * Heading of the pre-approval screen
+     * Heading of the pre-approval screen.
      */
     heading: string
 
     /**
-     * Message to the user
+     * Message to the user.
      */
      message: string
 
     /**
-     * Array of items to be displayed as list of choices
+     * Array of items to be displayed as list of choices.
      */
     items?: string[]
 
     /**
-     * Type of the approval button
+     * Type of the approval button.
      */
     approvalType?: "SLIDER" | "BUTTON"
 }
@@ -83,15 +83,15 @@ export interface WMTPostApprovalScreen {
 // --- REVIEW POST APPROVAL ---
 
 export interface WMTPostApprovalScreenReview extends WMTPostApprovalScreen {
-    /** Heading of the post-approval screen */
+    /** Heading of the post-approval screen. */
     heading: string
-    /** Message to the user */
+    /** Message to the user. */
     message: string
-    /** Payload with data for the review */
+    /** Payload with data for the review. */
     payload: WMTReviewPostApprovalScreenPayload
 }
 
-/** Review payload */
+/** Review payload. */
 export interface WMTReviewPostApprovalScreenPayload {
     /** List of the operation attributes */
     attributes: WMTUserOperationAttribute[]
@@ -120,10 +120,10 @@ export interface WMTRedirectPostApprovalScreenPayload {
 // --- GENERIC PSOT APPROVAL ---
 
 export interface WMTPostApprovalScreenGeneric extends WMTPostApprovalScreen {
-    /** Heading of the post-approval screen */
+    /** Heading of the post-approval screen. */
     heading: string
-    /** Message to the user */
+    /** Message to the user. */
     message: string
-    /** Payload */
+    /** Payload. */
     payload: any
 }

--- a/src/push/WMTPush.ts
+++ b/src/push/WMTPush.ts
@@ -24,7 +24,7 @@ export class WMTPush extends WMTNetworking {
   /** 
    * Registers the given powerauth activation for push notifications.
    * 
-   * @param token Push token
+   * @param token Push token.
    * @param platform ios, android or huawei. When not specified, `Platform.OS` is used to determine if ios or android will be used. There is currently no automatic huawei platform detection.
    * @param requestProcessor You may modify the request via this processor. It's highly recommended to only modify HTTP headers.
    * @returns Server response


### PR DESCRIPTION
Closes #23 .
- Tests are executing correctly on all platforms & stacks.
- The `PWAExtension` gets properly emitted & compiled both in RN and CDV, however with a small nasty CDV/TS workaround.
