### PR TITLE
[2.1.x] Added missing migration instruction in docs

### DIFF
--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -7,3 +7,4 @@ When updating across multiple versions, you need to perform all migration steps 
 <!-- end -->
 
 - [Migration from version `beta` to `1.0.x`](Version-1.0.md)
+- [Migration from version `2.0.x` to `2.1.x`](Version-2.1.md)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -11,3 +11,4 @@
 **Other**
 
 - [Changelog](./Changelog.md)
+- [Migration Guide](./Migration-Instructions.md)


### PR DESCRIPTION
Fix for the release branch